### PR TITLE
Add initial docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# Agent guidance – newfold-labs/container
+
+This file gives AI agents a quick orientation to the repo. For full detail, see the **docs/** directory.
+
+## What this project is
+
+- **newfold-labs/container** – Lightweight, PSR-11-compatible dependency injection container used by the Newfold Module Loader and brand plugins. Supports get/set, factories (new instance each time), services (singleton per id), and computed values. Implemented in PHP with no framework dependencies. Maintained by Newfold Labs.
+
+- **Stack:** PHP 7.0+ (see `composer.json`). No frontend; consumed as a Composer dependency by wp-module-loader and host plugins.
+
+- **Architecture:** Host or loader instantiates `NewfoldLabs\Container\Container`, registers entries with `set()`, `service()`, or `factory()`, then passes the container to the loader. The wp-module-loader extends this container and uses it to provide the plugin instance and other shared state to modules.
+
+## Key paths
+
+| Purpose | Location |
+|---------|----------|
+| Container implementation | `includes/Container.php` |
+| PSR-11 interface | `includes/ContainerInterface.php` |
+| Exceptions | `includes/ContainerException.php`, `includes/NotFoundException.php` and interfaces |
+
+## Essential commands
+
+```bash
+composer install
+```
+
+No test or lint scripts in this repo.
+
+## Documentation
+
+- **Full documentation** is in **docs/**. Start with **docs/index.md**.
+- **CLAUDE.md** is a symlink to this file (AGENTS.md).
+
+---
+
+## Keeping documentation current
+
+**When you change code, features, or workflows, update the docs so they stay accurate.**
+
+- Keep all docs current, not only the ones listed here.
+- Prefer updating the appropriate file(s) in **docs/** over leaving docs out of date.
+- When adding or changing the public API, update **docs/integration.md** or **docs/overview.md**. When cutting a release, update **docs/changelog.md** if the repo is released.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,7 +35,7 @@ No test or lint scripts in this repo.
 
 ## Keeping documentation current
 
-**When you change code, features, or workflows, update the docs so they stay accurate.**
+**When you change code, features, or workflows, update the docs so they stay accurate.** Keep **docs/index.md** current: when you add, remove, or rename doc files, update the table of contents (and quick links if present).
 
 - Keep all docs current, not only the ones listed here.
 - Prefer updating the appropriate file(s) in **docs/** over leaving docs out of date.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,1 @@
+AGENTS.md

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,3 +1,10 @@
+---
+name: container
+title: Development
+description: Lint, test, and workflow.
+updated: 2025-03-18
+---
+
 # Development
 
 This package has no test suite or lint scripts in the repo. When contributing:

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,7 @@
+# Development
+
+This package has no test suite or lint scripts in the repo. When contributing:
+
+1. Follow PSR-11 and the existing style in `includes/`.
+2. Keep the container minimal; it is a core dependency of the loader and many modules.
+3. When cutting a release (e.g. to Newfold Satis), update **docs/changelog.md** with the version and changes.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,3 +1,10 @@
+---
+name: container
+title: Getting started
+description: Prerequisites, install, and run.
+updated: 2025-03-18
+---
+
 # Getting started
 
 ## Prerequisites

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,0 +1,33 @@
+# Getting started
+
+## Prerequisites
+
+- **PHP** 7.0+ (see `composer.json`).
+- **Composer**.
+
+## Install
+
+From the package root:
+
+```bash
+composer install
+```
+
+No production dependencies other than PHP.
+
+## Minimal usage
+
+```php
+use NewfoldLabs\Container\Container;
+
+$container = new Container();
+$container->set( 'plugin', $plugin_instance );
+$container->set( 'cache_types', [ 'browser', 'skip404' ] );
+$container->set( 'my_service', $container->service( function ( $c ) {
+    return new MyService( $c->get( 'plugin' ) );
+} ) );
+
+$service = $container->get( 'my_service' ); // same instance each time
+```
+
+See [integration.md](integration.md) for how the loader and host plugins use the container.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,3 +1,10 @@
+---
+name: container
+title: Documentation index
+description: Table of contents and quick links.
+updated: 2025-03-18
+---
+
 # newfold-labs/container – Documentation index
 
 Documentation for the Newfold container package, for **humans** and **AI agents**. Start here.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,19 @@
+# newfold-labs/container – Documentation index
+
+Documentation for the Newfold container package, for **humans** and **AI agents**. Start here.
+
+## Table of contents
+
+| Document | Description |
+|----------|-------------|
+| [overview.md](overview.md) | What the container does, PSR-11, and main API. |
+| [getting-started.md](getting-started.md) | Install and minimal usage. |
+| [integration.md](integration.md) | How wp-module-loader and host plugins use the container. |
+| [development.md](development.md) | Contributing and release notes. |
+
+## Quick links
+
+- **New to the repo:** [overview.md](overview.md) then [getting-started.md](getting-started.md).
+- **Using in a module or host:** [integration.md](integration.md).
+
+Root **AGENTS.md** gives a short agent summary and points here.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,0 +1,18 @@
+# Integration
+
+## How the loader uses the container
+
+**wp-module-loader** depends on `newfold-labs/container`. The host plugin (e.g. Bluehost) creates a container, registers the plugin instance and any config (e.g. brand, cache types, marketplace brand), then passes it to the loader via `NewfoldLabs\WP\ModuleLoader\container( $container )`. The loader extends the container as `NewfoldLabs\WP\ModuleLoader\Container` (adding `plugin()`) and uses it when running each module’s callback: `$module->callback( container(), $module )`.
+
+So the host never instantiates the loader’s extended container directly; it instantiates the base `NewfoldLabs\Container\Container` (or the loader’s `Container` which extends it), sets entries, then calls `container( $container )` so the loader and all modules share that instance.
+
+## Typical host setup
+
+1. Create container: `$container = new \NewfoldLabs\Container\Container();` (or the loader’s extended class).
+2. Set plugin and config: `$container->set( 'plugin', new Plugin( ... ) );`, `$container->set( 'cache_types', ... );`, etc.
+3. Set the container on the loader: `\NewfoldLabs\WP\ModuleLoader\container( $container );`
+4. Load modules (via Composer autoload); they register with the loader and receive `container()` in their callback.
+
+## Where context lives
+
+Context (brand, platform) is not stored in the container; it is provided by **wp-module-context** via `setContext()` / `getContext()`. The runtime (wp-module-runtime) reads from the container (e.g. `capabilities`) and from filters (e.g. `newfold_runtime`) to build `window.NewfoldRuntime`.

--- a/docs/integration.md
+++ b/docs/integration.md
@@ -1,3 +1,10 @@
+---
+name: container
+title: Integration
+description: How the module registers and integrates.
+updated: 2025-03-18
+---
+
 # Integration
 
 ## How the loader uses the container

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,3 +1,10 @@
+---
+name: container
+title: Overview
+description: What the module does and who maintains it.
+updated: 2025-03-18
+---
+
 # Overview
 
 ## What this package does

--- a/docs/overview.md
+++ b/docs/overview.md
@@ -1,0 +1,21 @@
+# Overview
+
+## What this package does
+
+**newfold-labs/container** is a small PSR-11-compatible dependency injection container. It is used by the Newfold Module Loader and by WordPress brand plugins (e.g. Bluehost) to hold shared state (plugin instance, capabilities, cache types, etc.) and to provide services/factories so modules receive the same container instance.
+
+- **PSR-11:** Implements `ContainerInterface` (`get`, `has`). Throws `NotFoundException` when an entry is missing.
+- **Entries:** Set with `set( $id, $value )`. Values can be raw, or wrapped with `service( Closure )` (singleton per id) or `factory( Closure )` (new instance each time). Also supports `computed( Closure )` for one-off computation.
+- **ArrayAccess & Iterator:** The container implements `ArrayAccess` and `Iterator` for convenience.
+
+## Who maintains it
+
+- **Newfold Labs** (Newfold Digital). Distributed via Newfold Satis. Used by wp-module-loader and all Newfold WordPress brand plugins.
+
+## High-level features
+
+- `get( $id )`, `has( $id )`, `set( $id, $value )`, `raw( $id )`, `delete( $id )`
+- `service( Closure )` – resolve once per id and reuse
+- `factory( Closure )` – resolve every time
+- `extend( $id, Closure )` – wrap an existing factory/service
+- `keys()`, `count()`, iteration


### PR DESCRIPTION
Adds AGENTS.md, CLAUDE.md (symlink to AGENTS.md), and docs/ per the Newfold modules documentation rollout: overview, getting-started, integration, development.

Made with [Cursor](https://cursor.com)